### PR TITLE
Defer to xcodebuild to validate simulator versions

### DIFF
--- a/simulator_control/simulator_util.py
+++ b/simulator_control/simulator_util.py
@@ -310,8 +310,6 @@ def CreateNewSimulator(device_type=None, os_version=None, name_prefix=None):
           'os versions are %s.' % (os_version, supported_sim_os_versions))
   if not device_type:
     device_type = GetLastSupportedIphoneSimType(os_version)
-  else:
-    _ValidateSimulatorTypeWithOsVersion(device_type, os_version)
   if not name_prefix:
     name_prefix = 'New'
   name = '%s-%s-%s' % (name_prefix, device_type, os_version)
@@ -580,34 +578,6 @@ def _ValidateSimulatorType(device_type):
     raise ios_errors.IllegalArgumentError(
         'The simulator device type %s is not supported. Supported simulator '
         'device types are %s.' % (device_type, supported_sim_device_types))
-
-
-def _ValidateSimulatorTypeWithOsVersion(device_type, os_version):
-  """Checks if the simulator type with the given os version is valid.
-
-  Args:
-    device_type: string, device type of the new simulator. The value corresponds
-      to the output of `xcrun simctl list devicetypes`. E.g., iPhone 6, iPad
-      Air, etc.
-    os_version: string, OS version of the new simulator. The format is
-      {major}.{minor}, such as 9.3, 10.2.
-
-  Raises:
-    ios_errors.IllegalArgumentError: when the given simulator device type can
-        not match the given OS version.
-  """
-  os_version_float = float(os_version)
-  sim_profile = simtype_profile.SimTypeProfile(device_type)
-  min_os_version_float = float(sim_profile.min_os_version)
-  if min_os_version_float > os_version_float:
-    raise ios_errors.IllegalArgumentError(
-        'The min OS version of %s is %s. But current OS version is %s' %
-        (device_type, min_os_version_float, os_version))
-  max_os_version_float = float(sim_profile.max_os_version)
-  if max_os_version_float < os_version_float:
-    raise ios_errors.IllegalArgumentError(
-        'The max OS version of %s is %s. But current OS version is %s' %
-        (device_type, max_os_version_float, os_version))
 
 
 def QuitSimulatorApp():

--- a/test_runner/xctestrun.py
+++ b/test_runner/xctestrun.py
@@ -292,7 +292,6 @@ class XctestRunFactory(object):
     self._xctestrun_obj = None
     self._xctestrun_dict = None
     self._delete_work_dir = False
-    self._ValidateArguments()
 
   def __enter__(self):
     return self.GenerateXctestrun()
@@ -366,26 +365,6 @@ class XctestRunFactory(object):
     """Deletes the temp directories."""
     if self._delete_work_dir and os.path.exists(self._work_dir):
       shutil.rmtree(self._work_dir)
-
-  def _ValidateArguments(self):
-    """Checks whether the arguments of this class are valid.
-
-    Raises:
-      IllegalArgumentError: when the sdk or test type is not supported.
-    """
-    if self._sdk not in ios_constants.SUPPORTED_SDKS:
-      raise ios_errors.IllegalArgumentError(
-          'The sdk %s is not supported. Supported sdks are %s.'
-          % (self._sdk, ios_constants.SUPPORTED_SDKS))
-    if self._test_type not in ios_constants.SUPPORTED_TEST_TYPES:
-      raise ios_errors.IllegalArgumentError(
-          'The test type %s is not supported. Supported test types are %s.'
-          % (self._test_type, ios_constants.SUPPORTED_TEST_TYPES))
-    if (self._test_type == ios_constants.TestType.LOGIC_TEST and
-        self._on_device):
-      raise ios_errors.IllegalArgumentError(
-          'Only support running logic test on sdk iphonesimulator. '
-          'Current sdk is %s' % self._sdk)
 
   def _GenerateTestRootForXcuitest(self):
     """Generates the test root for XCUITest.


### PR DESCRIPTION
Currently the code attempts to validate runtimes, which can get thrown
off in a few scenarios.

By deferring to `xcodebuild` / Apple to validate options, it's easier to
maintain the xctestrunner

Fixes: https://github.com/google/xctestrunner/issues/12